### PR TITLE
Convert to module to allow for proper import

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "remove-unused-css",
   "version": "1.0.0",
   "description": "Small module for filtering out unused css rules.",
+  "type": "module",
   "main": "build/index.js",
   "scripts": {
     "test": "mocha --require babel-register tests/*",


### PR DESCRIPTION
Explicitly sets module type, later versions of node are more strict